### PR TITLE
401 response

### DIFF
--- a/src/main/java/com/example/eco_map/security/JwtSecurityContextRepository.java
+++ b/src/main/java/com/example/eco_map/security/JwtSecurityContextRepository.java
@@ -3,6 +3,7 @@ package com.example.eco_map.security;
 import com.example.eco_map.usecases.AuthenticationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.security.web.server.context.ServerSecurityContextRepository;
@@ -24,6 +25,7 @@ public class JwtSecurityContextRepository implements ServerSecurityContextReposi
     public Mono<SecurityContext> load(ServerWebExchange exchange) {
         return extractToken(exchange)
                 .flatMap(authenticationService::validateToken)
+                .onErrorResume(AuthenticationException.class, e -> Mono.empty())
                 .map(userDetails -> new UsernamePasswordAuthenticationToken(
                         userDetails, null, userDetails.getAuthorities()))
                 .map(SecurityContextImpl::new);


### PR DESCRIPTION
Дело было в нарушении контракта ServerSecurityContextRepository. `load()` должен возвращать или context, или пустой Mono. Второй результат означает, что аутентификация не пройдена. 
А вот поведение на случай `Mono.error` в Спринге не прописано.
Поэтому меняем ошибки на empty, и все заработало